### PR TITLE
Fix sed command

### DIFF
--- a/terraform/install.sh
+++ b/terraform/install.sh
@@ -1,4 +1,3 @@
-# gcloud services enable cloudfunctions.googleapis.com
 random_chars=$(cat /dev/urandom | tr -cd 'a-f0-9' | head -c 32)
 random_int=$(( RANDOM % 60 ))
 
@@ -27,6 +26,9 @@ if [[ $entervalue -ne 'yes' ]]; then
     exit 1
 fi
 
+# Set up project
+gcloud config set project $1
+
 # Create and update the Terraform main.tf with your state bucket name
 gsutil mb gs://tf_state_otgc_${random_chars}
 gcloud services enable cloudfunctions.googleapis.com
@@ -36,20 +38,22 @@ sed -i "s/\(MANUAL_EDIT_WRITE_YOUR_BUCKET\)/tf_state_otgc_${random_chars}/m" ./m
 # Create terraform.tfvars.example
 cp terraform.tfvars.example terraform.tfvars
 
-sed -i "s/\(your_project\)/$1/m" ./terraform.tfvars
-sed -i "s/\(your_onboard_username\)/$6/m" ./terraform.tfvars
-sed -i "s/\(your_onboard_password\)/$7/m" ./terraform.tfvars
-sed -i "s/\(your_function\)/otgc_function_${random_chars}/m" ./terraform.tfvars
-sed -i "s/\(your_cron_expression\)/${random_int} \*\/1 \* \* \*\\ /m" ./terraform.tfvars
+sed -i "s/your_project/$1/m" ./terraform.tfvars
+sed -i "s/your_onboard_username/$6/m" ./terraform.tfvars
+sed -i "s/your_onboard_password/$7/m" ./terraform.tfvars
+sed -i "s/\(your_function/otgc_function_${random_chars}/m" ./terraform.tfvars
+sed -i "s/\(your_cron_expression/${random_int} \*\/1 \* \* \*\\ /m" ./terraform.tfvars
 
 # Update values in config.ini
 cd ../
 
+replacement_refresh_token=$4
+
 cp config_example.ini config.ini
-sed -i "s/\yourcalendar@group.calendar.google.com\)/$5/m" ./config.ini
-sed -i "s/\(your_client_id\)/$2/m" ./config.ini
-sed -i "s/\(your_client_secret\)/$3/m" ./config.ini
-sed -i "s/\(your_refresh_token\)/$4/m" ./config.ini
+sed -i "s/yourcalendar@group.calendar.google.com/$5/m" ./config.ini
+sed -i "s/your_client_id/$2/m" ./config.ini
+sed -i "s/your_client_secret/$3/m" ./config.ini
+sed -i --expression "s@your_refresh_token@$replacement_refresh_token@" ./config.ini
 
 cd terraform
 


### PR DESCRIPTION
Slashes in the refresh token were interpreted by `sed`. No longer the case with this fix.